### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,28 +7,28 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-A6lib                  KEYWORD1
-callInfo               KEYWORD1
+A6lib	KEYWORD1
+callInfo	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin                  KEYWORD2
-powerCycle             KEYWORD2
+begin	KEYWORD2
+powerCycle	KEYWORD2
 
-dial                   KEYWORD2
-redial                 KEYWORD2
-hangUp                 KEYWORD2
-checkCallStatus        KEYWORD2
-getSignalStrength      KEYWORD2
+dial	KEYWORD2
+redial	KEYWORD2
+hangUp	KEYWORD2
+checkCallStatus	KEYWORD2
+getSignalStrength	KEYWORD2
 
-sendSMS                KEYWORD2
+sendSMS	KEYWORD2
 
-setVol                 KEYWORD2
-enableSpeaker          KEYWORD2
+setVol	KEYWORD2
+enableSpeaker	KEYWORD2
 
-A6conn                 KEYWORD2
+A6conn	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/A6lib.cpp
+++ b/src/A6lib.cpp
@@ -660,6 +660,9 @@ bool A6lib::sendPDU(const String& number, const String& content) {
 	}
 
 	LOG("Send PDU to %s", number.c_str());
+	if (sca.charAt(0) == '+')
+		sca.remove(0, 1);
+
 	if (sca.startsWith("00"))
 		sca.remove(0, 2);
 	else if (sca.startsWith("0"))
@@ -718,6 +721,9 @@ bool A6lib::sendPDU(const String& number, wchar_t* content, uint8_t len) {
 	}
 
 	LOG("Send PDU to %s", number.c_str());
+	if (sca.charAt(0) == '+')
+		sca.remove(0, 1);
+
 	if (sca.startsWith("00"))
 		sca.remove(0, 2);
 	else if (sca.startsWith("0"))


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords